### PR TITLE
Remove some incorrect & unnecessary things from video example.

### DIFF
--- a/src/js-library/example-apps.md
+++ b/src/js-library/example-apps.md
@@ -24,7 +24,7 @@ A barebones [video chat](http://jsbin.com/huqij) example with jQuery.
 ([source](http://jsbin.com/huqij/edit))
 
 A barebones [video chat](/tutorials/video-chat-example.html) example with Angular.
-([source](http://jsfiddle.net/ruffrey/Kfp47/))
+([source](http://jsfiddle.net/ruffrey/Kfp47/10))
 
 A space themed [messaging and group chat solution](http://sc.digiumlabs.com),
 with audio and video calling.

--- a/src/js-library/video-chat-example.html
+++ b/src/js-library/video-chat-example.html
@@ -35,11 +35,6 @@
 				$scope.friendId = "";
 
 				var callOptions = {
-			    	constraints: {audio: true, video: true},
-
-			    	onPreviewLocalMedia: function(evt) {
-			    		setVideo('localVideoSource', evt.element)
-			    	},
 			    	onLocalMedia: function(evt) {
 			    		setVideo('localVideoSource', evt.element)
 			    	},

--- a/src/js-library/video-chat.md
+++ b/src/js-library/video-chat.md
@@ -145,12 +145,6 @@ Throw the call options in an object. `setVideo` is called inside the callbacks.
 
 ```javascript
 var callOptions = {
-    constraints: {audio: true, video: true},
-
-    // your video
-    onPreviewLocalMedia: function(evt) {
-        setVideo('localVideoSource', evt.element)
-    },
     // your video
     onLocalMedia: function(evt) {
         setVideo('localVideoSource', evt.element)
@@ -201,7 +195,7 @@ $scope.client.listen('call', function(evt) {
 
 [See it in action &raquo;](video-chat-example.html)
 
-[Fiddle with it &raquo;](http://jsfiddle.net/ruffrey/Kfp47/1/)
+[Fiddle with it &raquo;](http://jsfiddle.net/ruffrey/Kfp47/10/)
 
 ```html
 <!doctype html>
@@ -241,11 +235,6 @@ $scope.client.listen('call', function(evt) {
                 $scope.friendId = "";
 
                 var callOptions = {
-                    constraints: {audio: true, video: true},
-
-                    onPreviewLocalMedia: function(evt) {
-                        setVideo('localVideoSource', evt.element)
-                    },
                     onLocalMedia: function(evt) {
                         setVideo('localVideoSource', evt.element)
                     },


### PR DESCRIPTION
`previewLocalMedia` was named incorrectly, and it wasn't doing what it was supposed to do if it *was* named correctly. Also `constraints` is unnecessary, because we weren't changing them from the defaults. Update the fiddle to match the new code.