### PR TITLE
Add TTL to token request body

### DIFF
--- a/examples/endpoint-authentication.sh
+++ b/examples/endpoint-authentication.sh
@@ -8,7 +8,8 @@
 body='{
     "appId": "'$appId'",
     "endpointId": "'$endpointId'",
-    "roleId": "'$roleId'"
+    "roleId": "'$roleId'",
+    "ttl": 3600
 }'
 
 # {


### PR DESCRIPTION
I tried the example myself, and got a 400 error because the TTL was missing from the token request body.