### PR TITLE
Correct video examples markdown

### DIFF
--- a/src/client/javascript/guide/audio-calling.md
+++ b/src/client/javascript/guide/audio-calling.md
@@ -22,7 +22,7 @@ Audio calling is easy using Respoke. First connect to Respoke either in [develop
 Next, create DOM elements to hang the WebRTC call.
 
    ```
-   <video id="localvideo"></video>
+   <video id="localVideo"></video>
    <video id="remoteVideo"></video>
    ```
 
@@ -46,12 +46,12 @@ First, listen for incoming calls.
     client.listen("call", function(e) {
         var call = e.call;
     });
-    
+
 Finally, answer the incoming call.
 
     client.listen("call", function(e) {
         var call = e.call;
-       
+
         // Show some UI to answer or hangup the call
         // For illustration, let us just answer the call
         if(call.caller !== true) {
@@ -61,7 +61,7 @@ Finally, answer the incoming call.
             });
         }
     });
-    
+
 The audio call is now setup for both the local client and the remote peer.
 
 
@@ -70,11 +70,11 @@ The audio call is now setup for both the local client and the remote peer.
 You can mute or unmute an audio call.
 
     call.toggleAudio();
-    
+
 Additionally, you can hangup a call.
 
-    call.hangup(); 
-    
+    call.hangup();
+
 Hanging up a call will trigger a hangup event.
 
     call.listen("hangup", function(e) {

--- a/src/client/javascript/guide/screen-sharing.md
+++ b/src/client/javascript/guide/screen-sharing.md
@@ -22,7 +22,7 @@ Screen sharing is easy using Respoke. First connect to Respoke either in [develo
 Next, create DOM elements to hang the WebRTC call.
 
    ```
-   <video id="localvideo"></video>
+   <video id="localVideo"></video>
    <video id="remoteVideo"></video>
    ```
 
@@ -46,12 +46,12 @@ First, listen for incoming calls.
     client.listen("call", function(e) {
         var call = e.call;
     });
-    
+
 Finally, answer the incoming call.
 
     client.listen("call", function(e) {
         var call = e.call;
-       
+
         if(call.caller !== true) {
             call.answer({
                 videoLocalElement: document.getElementById("localVideo"),
@@ -59,8 +59,8 @@ Finally, answer the incoming call.
             });
         }
     });
-    
-The screen share is now setup for both the local client and the remote peer. Only one person can screen share at a time. 
+
+The screen share is now setup for both the local client and the remote peer. Only one person can screen share at a time.
 
 For example, say the local user is sharing his screen and the remote user is looking at his screen. Since only one person can screen share, the remote user will not have any video input, so from the local user's POV, he's starting at a blank wall.
 
@@ -72,15 +72,15 @@ Consider starting a [video call](/client/javascript/guide/video-calling.html) fo
 You can hide or show your screen during a screen sharing call.
 
     call.toggleVideo();
-    
+
 Additionally, you can mute or unmute a screen sharing call's audio.
 
     call.toggleAudio();
-    
+
 Finally, you can hangup a call.
 
-    call.hangup(); 
-    
+    call.hangup();
+
 Hanging up a call will trigger a hangup event.
 
     call.listen("hangup", function(e) {

--- a/src/client/javascript/guide/video-calling.md
+++ b/src/client/javascript/guide/video-calling.md
@@ -22,7 +22,7 @@ Video calling is easy using Respoke. First connect to Respoke either in [develop
 Next, create DOM elements to hang the WebRTC call.
 
    ```
-   <video id="localvideo"></video>
+   <video id="localVideo"></video>
    <video id="remoteVideo"></video>
    ```
 
@@ -46,12 +46,12 @@ First, listen for incoming calls.
     client.listen("call", function(e) {
         var call = e.call;
     });
-    
+
 Finally, answer the incoming call.
 
     client.listen("call", function(e) {
         var call = e.call;
-       
+
         // Show some UI to answer or hangup the call
         // For illustration, let us just answer the call
         if(call.caller !== true) {
@@ -61,7 +61,7 @@ Finally, answer the incoming call.
             });
         }
     });
-    
+
 The video call is now setup for both the local client and the remote peer.
 
 
@@ -70,15 +70,15 @@ The video call is now setup for both the local client and the remote peer.
 You can hide or show video during a video call.
 
     call.toggleVideo();
-    
+
 Additionally, you can mute or unmute a video call's audio.
 
     call.toggleAudio();
-    
+
 Finally, you can hangup a call.
 
-    call.hangup(); 
-    
+    call.hangup();
+
 Hanging up a call will trigger a hangup event.
 
     call.listen("hangup", function(e) {


### PR DESCRIPTION
The examples assume that the video node is called `localVideo` rather than `localvideo`. This PR aligns both the HTML and JS ids.

A long term fix may be to validate that if calls to `startAudioCall` etc. are passed the keys `videoLocalElement`/`videoRemoteElement` with an undefined value then a warning / error is raised.