### PR TITLE
Add warnings for getUserMedia and beta feature use

### DIFF
--- a/scss/site.scss
+++ b/scss/site.scss
@@ -132,3 +132,39 @@
         }
     }
 }
+
+.notice {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #bcdff1;
+    background-color: #d9edf7;
+    color: #31708f;
+    padding: 20px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+
+    h3 {
+        font-size: 1.2em;
+        color: $red;
+        margin-bottom: 5px !important;
+    }
+}
+
+.warning {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    border: 1px solid #d4bf9b;
+    background-color: #fcf8e3;
+    color: #8a6d3b;
+    padding: 20px;
+    -webkit-border-radius: 5px;
+    -moz-border-radius: 5px;
+    border-radius: 5px;
+
+    h3 {
+        font-size: 1.2em;
+        color: $red;
+        margin-bottom: 5px !important;
+    }
+}

--- a/src/client/javascript/guide/asterisk-calling.md
+++ b/src/client/javascript/guide/asterisk-calling.md
@@ -18,6 +18,15 @@ meta:
 Asterisk Calling is easy using Respoke. First, you must [authenticate](/client/javascript/guide/authentication.html)
 before connecting to Respoke. Then we're ready to start writing some code.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
 ## Starting Asterisk Calls
 
 Next, get the local endpoint configured on asterisk and start an audio call.

--- a/src/client/javascript/guide/audio-calling.md
+++ b/src/client/javascript/guide/audio-calling.md
@@ -22,6 +22,15 @@ You have read the [Getting Started Guide](/client/javascript/getting-started.htm
 <a href="https://docs.respoke.io/js-library/respoke.Client.html#connect" target+"_blank">connected</a> your app to
 Respoke.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
 ## Starting a Call
 You initiate an audio call using the
 <a href="https://docs.respoke.io/js-library/respoke.Client.html#startAudioCall" target="_blank">startAudioCall</a>

--- a/src/client/javascript/guide/audio-conferencing.md
+++ b/src/client/javascript/guide/audio-conferencing.md
@@ -18,6 +18,22 @@ meta:
 Use audio conferencing to join multiple participants in a single conference room. Combine audio conferencing with groups
 to get a list of conference participants and keep track of participants joining and leaving.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
+<div class="warning">
+    <h3>Beta Feature</h3>
+    <p>Audio conferencing is currently in public beta and will need to be enabled in your account before you can use it.
+    If you would like to use this feature, please send an email to support@respoke.io and request that audio conferencing
+    be enabled for your account.
+    </p>
+</div>
 
 ## Starting Audio Conferencing
 

--- a/src/client/javascript/guide/phone-calling.md
+++ b/src/client/javascript/guide/phone-calling.md
@@ -19,6 +19,15 @@ Phone Calling is easy using Respoke. First, you must [authenticate](/client/java
 connecting to Respoke. Then [configure your App Role to use phone calling features](/portal/phone-numbers.html). Then
 we're ready to start writing some code.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
 ## Starting Phone Calls
 
 Next, get the mobile phone number or landline phone number to call and start an outgoing phone call.

--- a/src/client/javascript/guide/screen-sharing.md
+++ b/src/client/javascript/guide/screen-sharing.md
@@ -19,6 +19,21 @@ Screen sharing is easy using Respoke. First connect to Respoke either in
 [development mode](/client/javascript/getting-started.html) or
 [authenticated](/client/javascript/guide/authentication.html). Then we're ready to start writing some code.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
+<div class="warning">
+    <h3>Requires Plugin</h3>
+    <p>Screen sharing requires a plugin in all supported browsers. Please refer to the
+    <a href="/client/javascript/guide/screen-sharing-plugin.html">Screen Sharing Plugin</a> section of the guide for
+    more information on setting up a screen sharing plugin for your app.</p>
+</div>
 
 ## Starting Screen Shares
 

--- a/src/client/javascript/guide/video-calling.md
+++ b/src/client/javascript/guide/video-calling.md
@@ -22,6 +22,15 @@ You have read the [Getting Started Guide](/client/javascript/getting-started.htm
 <a href="https://docs.respoke.io/js-library/respoke.Client.html#connect" target+"_blank">connected</a> your app to
 Respoke.
 
+<div class="notice">
+    <h3>Heads up!</h3>
+    <p>Before the end of 2015, the Chrome browser (versions 47+) will require that all use of the `getUserMedia()`
+    browser API originate from a
+    "<a href="http://www.w3.org/TR/powerful-features/#is-origin-trustworthy">potentially trustworthy</a>" origin. This
+    means that deployed Respoke apps that use audio, video, or screen sharing features will need to be hosted on a
+    domain that is secure.
+</div>
+
 ## Starting a Video Call
 Before starting a video call you first need to add a few `<video>` elements to attach the call streams to.
 


### PR DESCRIPTION
This patch adds a warning on all docs guide pages for features that use getUserMedia, to indicate that deployed apps will need to be served on a "trustworthy origin" to work properly. This change to Chrome will seriously break lots of apps, so it's important that we give people a heads up. I went ahead and added some other warning boxes for features that require a flag to be set, or features that require a plugin.

----
![screen shot 2015-09-16 at 11 37 38 am](https://cloud.githubusercontent.com/assets/309219/9911436/b579810e-5c67-11e5-8ac1-f891f1c240c6.png)

----

![screen shot 2015-09-16 at 11 37 44 am](https://cloud.githubusercontent.com/assets/309219/9911434/b577a974-5c67-11e5-817b-c36da32dd02e.png)

----

![screen shot 2015-09-16 at 11 37 48 am](https://cloud.githubusercontent.com/assets/309219/9911433/b5762ec8-5c67-11e5-9c90-a56762b0b3a6.png)

----

![screen shot 2015-09-16 at 11 37 54 am](https://cloud.githubusercontent.com/assets/309219/9911435/b5780216-5c67-11e5-896a-04a12e2e069b.png)

----

![screen shot 2015-09-16 at 11 38 04 am](https://cloud.githubusercontent.com/assets/309219/9911437/b57a0d86-5c67-11e5-99a0-947e5eeedb07.png)

----

![screen shot 2015-09-16 at 11 38 09 am](https://cloud.githubusercontent.com/assets/309219/9911438/b57dd524-5c67-11e5-83d6-f2c4727a8641.png)

----

Related to MER-4346